### PR TITLE
Add 'autocheck' and 'type' support to menuitems

### DIFF
--- a/lib/ui/menuitems.js
+++ b/lib/ui/menuitems.js
@@ -25,10 +25,12 @@ function MenuitemOptions(options) {
     disabled: { is: ["undefined", "boolean"], map: function(v) !!v},
     accesskey: { is: ["undefined", "string"] },
     key: { is: ["undefined", "string"] },
+    autocheck: { is: ['undefined', 'boolean'] },
     checked: { is: ['undefined', 'boolean'] },
     className: { is: ["undefined", "string"] },
     onCommand: { is: ['undefined', 'function'] },
-    useChrome: { map: function(v) !!v }
+    useChrome: { map: function(v) !!v },
+    type: { is: ['undefined', 'string']}
   });
 }
 
@@ -45,16 +47,20 @@ let Menuitem = Class({
   get id() menuitemNS(this).options.id,
   get label() menuitemNS(this).options.label,
   set label(val) updateProperty(this, 'label', val),
+  get autocheck() menuitemNS(this).options.autocheck,
+  set autocheck(val) updateProperty(this, 'autocheck', !!val),
   get checked() menuitemNS(this).options.checked,
   set checked(val) updateProperty(this, 'checked', !!val),
   get disabled() menuitemNS(this).options.disabled,
   set disabled(val) updateProperty(this, 'disabled', !!val),
   get key() menuitemNS(this).options.key,
   set key(val) updateProperty(this, 'key', val),
+  get type() menuitemNS(this).options.type,
+  set type(val) updateProperty(this, 'type', val),
   clone: function (overwrites) {
     let opts = Object.clone(menuitemNS(this).options);
     for (let key in overwrites) {
-      opts[key] = ovrewrites[key];
+      opts[key] = overwrites[key];
     }
     return Menuitem(opts);
   },
@@ -65,7 +71,7 @@ let Menuitem = Class({
 
     forEachMI(function(menuitem, i, $) {
       updateMenuitemParent(menuitem, options, $);
-    });
+    }, this);
   },
   destroy: function() {
     if (!menuitemNS(this).destroyed) {
@@ -97,12 +103,16 @@ function addMenuitems(self, options) {
           window.document.createElementNS(NS_XUL, "menuitem"), options);
       var menuitems_i = menuitems.push(menuitem) - 1;
 
-      // add the menutiem to the ui
-      let added = updateMenuitemParent(menuitem, options, function(id) window.document.getElementById(id));
+      // add the menuitem to the ui
+      updateMenuitemParent(menuitem, options, function(id) window.document.getElementById(id));
 
       menuitem.addEventListener("command", function() {
-        if (!self.disabled)
+        if (!self.disabled) {
+          if (self.autocheck) {
+            updateProperty(self, 'checked', menuitem.getAttribute('checked') == "true");
+          }
           emit(self, 'command', options.useChrome ? window : null);
+        }
       }, true);
 
       // add unloader
@@ -125,7 +135,7 @@ function addMenuitems(self, options) {
 }
 
 function updateMenuitemParent(menuitem, options, $) {
-  // add the menutiem to the ui
+  // add the menuitem to the ui
   if (Array.isArray(options.menuid)) {
       let ids = options.menuid;
       for (var len = ids.length, i = 0; i < len; i++) {
@@ -157,8 +167,11 @@ function updateMenuitemAttributes(menuitem, options) {
     menuitem.style.listStyleImage = "url('" + options.image + "')";
   }
 
-  if (options.checked)
-    menuitem.setAttribute('checked', options.checked);
+  if (options.type)
+    menuitem.setAttribute("type", options.type);
+
+  menuitem.setAttribute('autocheck', !!options.autocheck);
+  menuitem.setAttribute('checked', !!options.checked);
 
   if (options.className)
     options.className.split(/\s+/).forEach(function(name) menuitem.classList.add(name));

--- a/test/test-menuitems.js
+++ b/test/test-menuitems.js
@@ -41,7 +41,7 @@ exports.testMIDoesExist = function(assert) {
   assert.equal(menuitem.getAttribute('accesskey'), '', 'menuitem accesskey is ok');
   assert.equal(menuitem.getAttribute('class'), '', 'menuitem class is ok');
   assert.equal(menuitem.nextSibling, undefined, 'menuitem is last');
-  assert.equal(menuitem.hasAttribute("checked"), false, 'menuitem not checked');
+  assert.equal(menuitem.getAttribute('checked'), 'false', 'menuitem not checked');
   mi.destroy();
   assert.ok(!$(options.id), 'menuitem is gone');
   assert.equal(menuitem.parentNode, null, 'menuitem has no parent');


### PR DESCRIPTION
I needed `autocheck` support in my project, which in turn needed `type` to be set correctly, so here is a patch adding them, with some drive-by fixes to typos in comments/variables.

I couldn't get tests to run properly, this might be an issue with the version of addon-sdk I'm using. I want to add more, but I figured I'd submit the PR to get an idea if this is something you'd want to have in the project first.